### PR TITLE
Fix pre-defined envoy locations not spawning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Improved folia support maybe?
 
 ## Bugs Fixed 🐛
+- Fixed pre-defined envoy locations not spawning when an event starts, the location cleaner was running after the crates were placed and removing them.
 - Fixed an issue with CMI Holograms by forking CMI and updating the API ourselves.
 
 As always, Report 🐛 to https://github.com/Crazy-Crew/CrazyEnvoys/issues

--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -778,55 +778,17 @@ public class CrazyManager {
         }
 
         for (Block block : dropLocations) {
-            if (block != null) {
-                boolean spawnFallingBlock = false;
+            if (block == null) continue;
 
-                if (this.config.getProperty(ConfigKeys.envoy_falling_block_toggle)) {
-                    for (Entity entity : Methods.getNearbyEntities(block.getLocation(), 40, 40, 40)) {
-                        if (entity instanceof Player) {
-                            spawnFallingBlock = true;
-
-                            break;
-                        }
-                    }
+            // Spawn on the region scheduler so the block is placed on the thread that owns its
+            // location (required on Folia). The location cleaner is scheduled first in removeAllEnvoys,
+            // so this runs after the old blocks are set to air instead of being wiped by them.
+            new FoliaScheduler(this.plugin, block.getLocation()) {
+                @Override
+                public void run() {
+                    spawnEnvoy(block);
                 }
-
-                if (spawnFallingBlock) {
-                    final Chunk chunk = block.getChunk();
-
-                    if (!chunk.isLoaded()) chunk.load();
-
-                    final int fallingHeight = this.config.getProperty(ConfigKeys.envoy_falling_height);
-
-                    final ItemType itemType = ItemUtils.getItemType(this.config.getProperty(ConfigKeys.envoy_falling_block_type).toLowerCase());
-
-                    if (itemType != null) {
-                        FallingBlock fallingBlock = block.getWorld().spawn(block.getLocation().add(.5, fallingHeight, .5), FallingBlock.class);
-                        fallingBlock.setBlockData(itemType.createItemStack().getType().createBlockData());
-
-                        fallingBlock.setDropItem(false);
-                        fallingBlock.setHurtEntities(false);
-
-                        this.fallingBlocks.put(fallingBlock, block);
-                    }
-                } else {
-                    Tier tier = pickRandomTier();
-
-                    final Chunk chunk = block.getChunk();
-
-                    if (!chunk.isLoaded()) chunk.load();
-
-                    block.setType(tier.getPlacedBlockMaterial());
-
-                    if (tier.isHoloEnabled() && this.holograms != null) this.holograms.createHologram(block.getLocation(), tier, MiscUtils.toString(block.getLocation()));
-
-                    addActiveEnvoy(block, tier);
-
-                    this.locationSettings.addActiveLocation(block);
-
-                    if (tier.getSignalFlareToggle() && chunk.isLoaded()) startSignalFlare(block.getLocation(), tier);
-                }
-            }
+            }.runNextTick();
         }
 
         this.runTimeTask = new FoliaScheduler(this.plugin, Scheduler.global_scheduler) {
@@ -845,6 +807,62 @@ public class CrazyManager {
         this.envoyTimeLeft = getEnvoyRunTimeCalendar();
 
         return true;
+    }
+
+    /**
+     * Spawns a single envoy crate at the given block.
+     * Must be run on the region that owns the block's location.
+     *
+     * @param block The block to spawn the crate at.
+     */
+    private void spawnEnvoy(final Block block) {
+        boolean spawnFallingBlock = false;
+
+        if (this.config.getProperty(ConfigKeys.envoy_falling_block_toggle)) {
+            for (Entity entity : Methods.getNearbyEntities(block.getLocation(), 40, 40, 40)) {
+                if (entity instanceof Player) {
+                    spawnFallingBlock = true;
+
+                    break;
+                }
+            }
+        }
+
+        if (spawnFallingBlock) {
+            final Chunk chunk = block.getChunk();
+
+            if (!chunk.isLoaded()) chunk.load();
+
+            final int fallingHeight = this.config.getProperty(ConfigKeys.envoy_falling_height);
+
+            final ItemType itemType = ItemUtils.getItemType(this.config.getProperty(ConfigKeys.envoy_falling_block_type).toLowerCase());
+
+            if (itemType != null) {
+                FallingBlock fallingBlock = block.getWorld().spawn(block.getLocation().add(.5, fallingHeight, .5), FallingBlock.class);
+                fallingBlock.setBlockData(itemType.createItemStack().getType().createBlockData());
+
+                fallingBlock.setDropItem(false);
+                fallingBlock.setHurtEntities(false);
+
+                this.fallingBlocks.put(fallingBlock, block);
+            }
+        } else {
+            Tier tier = pickRandomTier();
+
+            final Chunk chunk = block.getChunk();
+
+            if (!chunk.isLoaded()) chunk.load();
+
+            block.setType(tier.getPlacedBlockMaterial());
+
+            if (tier.isHoloEnabled() && this.holograms != null) this.holograms.createHologram(block.getLocation(), tier, MiscUtils.toString(block.getLocation()));
+
+            addActiveEnvoy(block, tier);
+
+            this.locationSettings.addActiveLocation(block);
+
+            if (tier.getSignalFlareToggle() && chunk.isLoaded()) startSignalFlare(block.getLocation(), tier);
+        }
     }
 
     /**


### PR DESCRIPTION
## What this fixes

Pre-defined envoy locations stop spawning on 26.1.2. When an event starts, no crates appear at the configured locations, and on regionised servers only the ones near a player appear.

## Cause

`546cac0` ("Wrap location cleaner in region scheduler") changed `cleanLocations()` to set blocks to air via `FoliaScheduler(...).runNextTick()`, deferring it to the next tick. The spawn loop in `startEnvoyEvent()` still places crates synchronously on the current tick, so the order flipped: crates are placed this tick, then the cleaner sets those same blocks back to air on the next tick.

This only affects pre-defined mode, because `cleanLocations()` adds every spawn location to the clear list, which is the exact set being placed. Random mode is unaffected since it only clears the previous event's `Locations.Spawned`.

The synchronous loop also ran on the caller's thread, so on Folia only the starter's region received crates and the auto timer spawned nothing. That is the "only spawns near me" report.

## Fix

Region schedule the spawn loop the same way `cleanLocations()` already is. The cleaner's tasks are submitted first, so per region the order is clear then place, and each crate is placed on the thread that owns its location. One change covers both the pre-defined wipe and the Folia behaviour. The per block logic is moved into a `spawnEnvoy(Block)` helper to keep the loop readable.

## Testing

Built against 26.1.2 and validated on a 26.1.2 server by swapping between the released jar and this build: pre-defined locations spawn correctly with the fix and fail without it.
