### PR TITLE
Fix pre-defined envoy locations not spawning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Improved folia support maybe?
 
 ## Bugs Fixed 🐛
+- Fixed pre-defined envoy locations not spawning when an event starts, the location cleaner was running after the crates were placed and removing them.
 - Fixed an issue with CMI Holograms by forking CMI and updating the API ourselves.
 
 As always, Report 🐛 to https://github.com/Crazy-Crew/CrazyEnvoys/issues

--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -778,55 +778,17 @@ public class CrazyManager {
         }
 
         for (Block block : dropLocations) {
-            if (block != null) {
-                boolean spawnFallingBlock = false;
+            if (block == null) continue;
 
-                if (this.config.getProperty(ConfigKeys.envoy_falling_block_toggle)) {
-                    for (Entity entity : Methods.getNearbyEntities(block.getLocation(), 40, 40, 40)) {
-                        if (entity instanceof Player) {
-                            spawnFallingBlock = true;
-
-                            break;
-                        }
-                    }
+            // Spawn on the region scheduler so the block is placed on the thread that owns its
+            // location (required on Folia). The location cleaner is scheduled first in removeAllEnvoys,
+            // so this runs after the old blocks are set to air instead of being wiped by them.
+            new FoliaScheduler(this.plugin, block.getLocation()) {
+                @Override
+                public void run() {
+                    spawnEnvoy(block);
                 }
-
-                if (spawnFallingBlock) {
-                    final Chunk chunk = block.getChunk();
-
-                    if (!chunk.isLoaded()) chunk.load();
-
-                    final int fallingHeight = this.config.getProperty(ConfigKeys.envoy_falling_height);
-
-                    final ItemType itemType = ItemUtils.getItemType(this.config.getProperty(ConfigKeys.envoy_falling_block_type).toLowerCase());
-
-                    if (itemType != null) {
-                        FallingBlock fallingBlock = block.getWorld().spawn(block.getLocation().add(.5, fallingHeight, .5), FallingBlock.class);
-                        fallingBlock.setBlockData(itemType.createItemStack().getType().createBlockData());
-
-                        fallingBlock.setDropItem(false);
-                        fallingBlock.setHurtEntities(false);
-
-                        this.fallingBlocks.put(fallingBlock, block);
-                    }
-                } else {
-                    Tier tier = pickRandomTier();
-
-                    final Chunk chunk = block.getChunk();
-
-                    if (!chunk.isLoaded()) chunk.load();
-
-                    block.setType(tier.getPlacedBlockMaterial());
-
-                    if (tier.isHoloEnabled() && this.holograms != null) this.holograms.createHologram(block.getLocation(), tier, MiscUtils.toString(block.getLocation()));
-
-                    addActiveEnvoy(block, tier);
-
-                    this.locationSettings.addActiveLocation(block);
-
-                    if (tier.getSignalFlareToggle() && chunk.isLoaded()) startSignalFlare(block.getLocation(), tier);
-                }
-            }
+            }.runNextTick();
         }
 
         this.runTimeTask = new FoliaScheduler(this.plugin, Scheduler.global_scheduler) {
@@ -845,6 +807,62 @@ public class CrazyManager {
         this.envoyTimeLeft = getEnvoyRunTimeCalendar();
 
         return true;
+    }
+
+    /**
+     * Spawns a single envoy crate at the given block.
+     * Must be run on the region that owns the block's location.
+     *
+     * @param block The block to spawn the crate at.
+     */
+    private void spawnEnvoy(final Block block) {
+        boolean spawnFallingBlock = false;
+
+        if (this.config.getProperty(ConfigKeys.envoy_falling_block_toggle)) {
+            for (Entity entity : Methods.getNearbyEntities(block.getLocation(), 40, 40, 40)) {
+                if (entity instanceof Player) {
+                    spawnFallingBlock = true;
+
+                    break;
+                }
+            }
+        }
+
+        if (spawnFallingBlock) {
+            final Chunk chunk = block.getChunk();
+
+            if (!chunk.isLoaded()) chunk.load();
+
+            final int fallingHeight = this.config.getProperty(ConfigKeys.envoy_falling_height);
+
+            final ItemType itemType = ItemUtils.getItemType(this.config.getProperty(ConfigKeys.envoy_falling_block_type).toLowerCase());
+
+            if (itemType != null) {
+                FallingBlock fallingBlock = block.getWorld().spawn(block.getLocation().add(.5, fallingHeight, .5), FallingBlock.class);
+                fallingBlock.setBlockData(itemType.createItemStack().getType().createBlockData());
+
+                fallingBlock.setDropItem(false);
+                fallingBlock.setHurtEntities(false);
+
+                this.fallingBlocks.put(fallingBlock, block);
+            }
+        } else {
+            Tier tier = pickRandomTier();
+
+            final Chunk chunk = block.getChunk();
+
+            if (!chunk.isLoaded()) chunk.load();
+
+            block.setType(tier.getPlacedBlockMaterial());
+
+            if (tier.isHoloEnabled() && this.holograms != null) this.holograms.createHologram(block.getLocation(), tier, MiscUtils.toString(block.getLocation()));
+
+            addActiveEnvoy(block, tier);
+
+            this.locationSettings.addActiveLocation(block);
+
+            if (tier.getSignalFlareToggle() && chunk.isLoaded()) startSignalFlare(block.getLocation(), tier);
+        }
     }
 
     /**


### PR DESCRIPTION
pre-defined envoy locations stopped spawning on 26.1.2. when an event starts the crates either don't show up at all, or on folia you only get the ones near whoever started it.

tracked it down to 546cac0 (the "wrap location cleaner in region scheduler" commit). that made `cleanLocations()` set the old blocks to air through `FoliaScheduler(...).runNextTick()`, so the clear now lands on the next tick. but the spawn loop in `startEnvoyEvent()` still places the crates synchronously on the current tick, so the order flipped: crates get placed this tick, then the cleaner runs next tick and sets those exact blocks back to air.

it only affects pre-defined mode because `cleanLocations()` dumps every spawn location into the clear list, which is the same set you just placed. random mode is fine since it only clears the previous event's `Locations.Spawned`, not the new spots, which is why it looked random who got hit.

the synchronous loop also runs on whatever thread called it, so on folia only the starter's region actually got crates and the auto timer spawned nothing. that's the "only spawns near me" reports.

fix is to region-schedule the spawn loop the same way `cleanLocations()` already does. the cleaner's tasks get queued first, so per region it goes clear then place, and each crate lands on the thread that owns its location. pulled the per-block logic into a `spawnEnvoy(Block)` helper so the loop stays readable. one change covers both the wipe and the folia behaviour.

tested on a 26.1.2 server by swapping between the current release jar (1.15.0) on purpur 26.1.2 and a build with this patch: pre-defined locations spawn fine with it, gone without it.